### PR TITLE
Insight: counter cache

### DIFF
--- a/app/controllers/counter_cacheable_query_sets_controller.rb
+++ b/app/controllers/counter_cacheable_query_sets_controller.rb
@@ -1,0 +1,17 @@
+class CounterCacheableQuerySetsController < ApplicationController
+  include UrlHasApp
+
+  before_action :assert_authenticated_as_app_user!
+
+  def show
+    render locals: {
+      counter_cacheable_query_set: query_set.decorate,
+    }
+  end
+
+  private
+
+  def query_set
+    app.counter_cacheable_query_sets.find(params[:id])
+  end
+end

--- a/app/decorators/counter_cacheable_query_set_decorator.rb
+++ b/app/decorators/counter_cacheable_query_set_decorator.rb
@@ -1,0 +1,43 @@
+class CounterCacheableQuerySetDecorator < Draper::Decorator
+  include DecoratesDuration
+
+  decorates_association :app
+
+  decorates_association :source
+
+  decorates_association :request
+
+  decorates_association :sql_events
+
+  delegate_all
+
+  delegate :name,
+    to: :app,
+    prefix: true
+
+  delegate :name,
+    to: :source,
+    prefix: true
+
+  delegate \
+      :name,
+      :duration,
+      :db_runtime,
+    to: :request,
+    prefix: true
+
+  def percentage_of_db_runtime
+    percentage(object.duration, request_db_runtime)
+  end
+
+  def percentage_of_request_duration
+    percentage(object.duration, request_duration)
+  end
+
+  private
+
+  def percentage(x, y)
+    return 0 if y.to_f.zero?
+    ((x / y.to_f) * 100).round(2)
+  end
+end

--- a/app/gendo/identifies_counter_cacheable_query_sets.rb
+++ b/app/gendo/identifies_counter_cacheable_query_sets.rb
@@ -1,0 +1,43 @@
+class IdentifiesCounterCacheableQuerySets
+  def self.identify(sql_events, options={})
+    new(sql_events, options).identify
+  end
+
+  def initialize(sql_events, options={})
+    @sql_events = sql_events
+    @minimum_query_occurrences = options[:minimum_query_occurrences] || 5
+  end
+
+  def identify
+    potential_events_by_association.select do |_, events|
+      events.size >= minimum_query_occurrences
+    end
+  end
+
+  def potential_events_by_association
+    potentials = {}
+    sql_events.each do |event|
+      if matches = matcher.match(event.sql)
+        association_name = matches[:association_name]
+        potentials[association_name] ||= []
+        potentials[association_name] << event
+      end
+    end
+    potentials
+  end
+
+  private
+
+  def matcher
+    @_matcher ||= /
+      # select count
+      SELECT \W* COUNT\(\*\) \W*
+
+      # table name
+      FROM \W* (?<association_name>\w*)
+    /x
+  end
+
+  attr_reader :sql_events
+  attr_reader :minimum_query_occurrences
+end

--- a/app/gendo/insights/request.rb
+++ b/app/gendo/insights/request.rb
@@ -5,6 +5,7 @@ module Insights
         SendEmailAsync,
         EagerLoadAssociations,
         BulkInsertData,
+        AddCounterCacheColumn,
       ]
     end
 

--- a/app/gendo/insights/request/add_counter_cache_column.rb
+++ b/app/gendo/insights/request/add_counter_cache_column.rb
@@ -1,0 +1,9 @@
+module Insights
+  module Request
+    class AddCounterCacheColumn < Base
+      def applicable?
+        request.counter_cacheable_query_sets.any?
+      end
+    end
+  end
+end

--- a/app/gendo/insights/source.rb
+++ b/app/gendo/insights/source.rb
@@ -5,6 +5,7 @@ module Insights
         SendEmailAsync,
         EagerLoadAssociations,
         BulkInsertData,
+        AddCounterCacheColumn,
       ]
     end
 

--- a/app/gendo/insights/source/add_counter_cache_column.rb
+++ b/app/gendo/insights/source/add_counter_cache_column.rb
@@ -1,0 +1,20 @@
+module Insights
+  module Source
+    class AddCounterCacheColumn < Base
+      REQUESTS_CHECKED_COUNT = 10
+
+      delegate :latest_counter_cacheable_query_set,
+        to: :source
+
+      def applicable?
+        CounterCacheableQuerySet.exists_for_requests?(latest_requests)
+      end
+
+      private
+
+      def latest_requests
+        source.latest_requests(limit: REQUESTS_CHECKED_COUNT)
+      end
+    end
+  end
+end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -18,6 +18,9 @@ class App < ActiveRecord::Base
   has_many :n_plus_one_queries,
     through: :requests
 
+  has_many :counter_cacheable_query_sets,
+    through: :requests
+
   has_many :mailer_events,
     through: :requests
 

--- a/app/models/counter_cacheable_query_set.rb
+++ b/app/models/counter_cacheable_query_set.rb
@@ -1,0 +1,21 @@
+class CounterCacheableQuerySet < ActiveRecord::Base
+  belongs_to :request
+
+  has_one :source,
+    through: :request
+
+  has_one :app,
+    through: :source
+
+  validates :request,
+    presence: true
+
+  validates :culprit_association_name,
+    presence: true
+
+  has_many :counter_cacheable_query_set_sql_events,
+    inverse_of: :counter_cacheable_query_set
+
+  has_many :sql_events,
+    through: :counter_cacheable_query_set_sql_events
+end

--- a/app/models/counter_cacheable_query_set.rb
+++ b/app/models/counter_cacheable_query_set.rb
@@ -22,4 +22,8 @@ class CounterCacheableQuerySet < ActiveRecord::Base
   def self.exists_for_requests?(requests)
     !!exists?(request_id: requests)
   end
+
+  def duration
+    sql_events.sum(:duration)
+  end
 end

--- a/app/models/counter_cacheable_query_set.rb
+++ b/app/models/counter_cacheable_query_set.rb
@@ -18,4 +18,8 @@ class CounterCacheableQuerySet < ActiveRecord::Base
 
   has_many :sql_events,
     through: :counter_cacheable_query_set_sql_events
+
+  def self.exists_for_requests?(requests)
+    !!exists?(request_id: requests)
+  end
 end

--- a/app/models/counter_cacheable_query_set_sql_event.rb
+++ b/app/models/counter_cacheable_query_set_sql_event.rb
@@ -1,0 +1,12 @@
+class CounterCacheableQuerySetSqlEvent < ActiveRecord::Base
+  belongs_to :counter_cacheable_query_set,
+    counter_cache: :sql_events_count
+
+  belongs_to :sql_event
+
+  validates :counter_cacheable_query_set,
+    presence: true
+
+  validates :sql_event,
+    presence: true
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -22,6 +22,10 @@ class Request < ActiveRecord::Base
     inverse_of: :request,
     dependent: :destroy
 
+  has_many :counter_cacheable_query_sets,
+    inverse_of: :request,
+    dependent: :destroy
+
   validates :source,
     presence: true
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -54,4 +54,11 @@ class Request < ActiveRecord::Base
       sql_events:         sql_events,
     )
   end
+
+  def create_counter_cacheable_query_set!(association_name, sql_events)
+    counter_cacheable_query_sets.create!(
+      culprit_association_name: association_name,
+      sql_events: sql_events,
+    )
+  end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -66,6 +66,10 @@ class Source < ActiveRecord::Base
     mailer_events.order(:created_at).last
   end
 
+  def latest_counter_cacheable_query_set
+    counter_cacheable_query_sets.order(:created_at).last
+  end
+
   def mailer_events_created_after(time)
     mailer_events.where("mailer_events.created_at > ?", time)
   end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -19,6 +19,9 @@ class Source < ActiveRecord::Base
   has_many :bulk_insertables,
     through: :requests
 
+  has_many :counter_cacheable_query_sets,
+    through: :requests
+
   validates :app,
     presence: true
 

--- a/app/views/counter_cacheable_query_sets/show.html.slim
+++ b/app/views/counter_cacheable_query_sets/show.html.slim
@@ -1,0 +1,53 @@
+- add_app_index_breadcrumb
+- add_app_breadcrumb(counter_cacheable_query_set)
+- add_source_breadcrumb(counter_cacheable_query_set)
+- add_request_breadcrumb(counter_cacheable_query_set)
+- add_crumb "counter cacheable",
+  app_counter_cacheable_query_set_path(counter_cacheable_query_set.app, counter_cacheable_query_set)
+
+.row
+  .small-12.columns
+    .panel
+
+      h3
+        ' Found
+        = counter_cacheable_query_set.sql_events_count
+        '  COUNT queries on
+        ' '#{counter_cacheable_query_set.culprit_association_name}'!
+
+      p
+        ' You may be able to entirely avoid querying
+        = counter_cacheable_query_set.culprit_association_name
+        '  by adding a counter cache column.
+
+      p
+        strong= counter_cacheable_query_set.request_db_runtime
+        '  was spent doing database processing during this request,
+        strong= counter_cacheable_query_set.duration
+        |  of which (
+        strong
+          = counter_cacheable_query_set.percentage_of_db_runtime
+          | %
+        ' ) was the detected queries.
+        .progress.large-12
+          span.meter(style="width: #{counter_cacheable_query_set.percentage_of_request_duration}%")
+
+      p
+        ' That's also
+        strong
+          = counter_cacheable_query_set.percentage_of_request_duration
+          | %
+        |  of the total request time (
+        strong= counter_cacheable_query_set.request_duration
+        | )!
+
+
+    table
+      thead
+        tr
+          th Started At
+          th Ended At
+          th Duration
+      tbody
+        - counter_cacheable_query_set.sql_events.each do |event|
+          = render "requests/sql_event_row", event: event

--- a/app/views/insights/request/_add_counter_cache_column.html.slim
+++ b/app/views/insights/request/_add_counter_cache_column.html.slim
@@ -1,0 +1,5 @@
+- request.counter_cacheable_query_sets.each do |query_set|
+  a(href="#")
+    ' Add a counter cache column to reduce the number of queries on
+    = query_set.culprit_association_name.pluralize
+    | .

--- a/app/views/insights/request/_add_counter_cache_column.html.slim
+++ b/app/views/insights/request/_add_counter_cache_column.html.slim
@@ -1,5 +1,5 @@
 - request.counter_cacheable_query_sets.each do |query_set|
-  a(href="#")
+  a(href=app_counter_cacheable_query_set_path(query_set.app, query_set))
     ' Add a counter cache column to reduce the number of queries on
     = query_set.culprit_association_name.pluralize
     | .

--- a/app/views/insights/source/_add_counter_cache_column.html.slim
+++ b/app/views/insights/source/_add_counter_cache_column.html.slim
@@ -6,4 +6,7 @@ p
   ' Recent requests appear to be repeatedly querying
   strong= counter_cacheable.culprit_association_name.pluralize
   '  for a record count. You maybe be able to reduce the total number of queries
-  ' by adding a counter cache column instead.
+  ' by
+  a(href=app_counter_cacheable_query_set_path(counter_cacheable.app, counter_cacheable))
+    ' adding a counter cache column
+  | instead.

--- a/app/views/insights/source/_add_counter_cache_column.html.slim
+++ b/app/views/insights/source/_add_counter_cache_column.html.slim
@@ -1,0 +1,9 @@
+- counter_cacheable = insight.latest_counter_cacheable_query_set
+
+h6 Counter Cache
+
+p
+  ' Recent requests appear to be repeatedly querying
+  strong= counter_cacheable.culprit_association_name.pluralize
+  '  for a record count. You maybe be able to reduce the total number of queries
+  ' by adding a counter cache column instead.

--- a/app/workers/identify_counter_cacheable_query_sets_worker.rb
+++ b/app/workers/identify_counter_cacheable_query_sets_worker.rb
@@ -1,0 +1,19 @@
+require 'sidekiq'
+
+class IdentifyCounterCacheableQuerySetsWorker
+  include Sidekiq::Worker
+
+  def self.in_request(request)
+    perform_async(request.id)
+  end
+
+  def perform(request_id)
+    request = Request.find(request_id)
+
+    queries = IdentifiesCounterCacheableQuerySets.identify(request.sql_events)
+
+    queries.each do |association_name, sql_events|
+      request.create_counter_cacheable_query_set!(association_name, sql_events)
+    end
+  end
+end

--- a/app/workers/process_request_payload_worker.rb
+++ b/app/workers/process_request_payload_worker.rb
@@ -13,5 +13,7 @@ class ProcessRequestPayloadWorker
     IdentifyNPlusOneQueriesWorker.in_request(request)
 
     IdentifyBulkInsertablesWorker.in_request(request)
+
+    IdentifyCounterCacheableQuerySetsWorker.in_request(request)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Gendo::Application.routes.draw do
   resources :apps, only: [:index, :new, :create, :show] do
     get :settings
 
+    resources :counter_cacheable_query_sets, only: [:show]
+
     resources :sources, only: [:show]
 
     resources :requests, only: [:show]

--- a/db/migrate/20131008110613_create_counter_cacheable_query_sets.rb
+++ b/db/migrate/20131008110613_create_counter_cacheable_query_sets.rb
@@ -1,0 +1,27 @@
+class CreateCounterCacheableQuerySets < ActiveRecord::Migration
+  def change
+    create_table :counter_cacheable_query_sets do |t|
+      t.references :request,
+        null: false
+
+      t.string :culprit_association_name,
+        null: false
+
+      t.integer :sql_events_count,
+        null: false,
+        default: 0
+
+      t.timestamps
+    end
+
+    create_table :counter_cacheable_query_set_sql_events do |t|
+      t.references :counter_cacheable_query_set,
+        null: false
+
+      t.references :sql_event,
+        null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -200,6 +200,71 @@ ALTER SEQUENCE bulk_insertables_id_seq OWNED BY bulk_insertables.id;
 
 
 --
+-- Name: counter_cacheable_query_set_sql_events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE counter_cacheable_query_set_sql_events (
+    id integer NOT NULL,
+    counter_cacheable_query_set_id integer NOT NULL,
+    sql_event_id integer NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: counter_cacheable_query_set_sql_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE counter_cacheable_query_set_sql_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: counter_cacheable_query_set_sql_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE counter_cacheable_query_set_sql_events_id_seq OWNED BY counter_cacheable_query_set_sql_events.id;
+
+
+--
+-- Name: counter_cacheable_query_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE counter_cacheable_query_sets (
+    id integer NOT NULL,
+    request_id integer NOT NULL,
+    culprit_association_name character varying(255) NOT NULL,
+    sql_events_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: counter_cacheable_query_sets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE counter_cacheable_query_sets_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: counter_cacheable_query_sets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE counter_cacheable_query_sets_id_seq OWNED BY counter_cacheable_query_sets.id;
+
+
+--
 -- Name: mailer_events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -521,6 +586,20 @@ ALTER TABLE ONLY bulk_insertables ALTER COLUMN id SET DEFAULT nextval('bulk_inse
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY counter_cacheable_query_set_sql_events ALTER COLUMN id SET DEFAULT nextval('counter_cacheable_query_set_sql_events_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY counter_cacheable_query_sets ALTER COLUMN id SET DEFAULT nextval('counter_cacheable_query_sets_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY mailer_events ALTER COLUMN id SET DEFAULT nextval('mailer_events_id_seq'::regclass);
 
 
@@ -595,6 +674,22 @@ ALTER TABLE ONLY bulk_insertable_sql_events
 
 ALTER TABLE ONLY bulk_insertables
     ADD CONSTRAINT bulk_insertables_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: counter_cacheable_query_set_sql_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY counter_cacheable_query_set_sql_events
+    ADD CONSTRAINT counter_cacheable_query_set_sql_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: counter_cacheable_query_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY counter_cacheable_query_sets
+    ADD CONSTRAINT counter_cacheable_query_sets_pkey PRIMARY KEY (id);
 
 
 --
@@ -844,3 +939,5 @@ INSERT INTO schema_migrations (version) VALUES ('20130922041241');
 INSERT INTO schema_migrations (version) VALUES ('20130925131559');
 
 INSERT INTO schema_migrations (version) VALUES ('20130928000652');
+
+INSERT INTO schema_migrations (version) VALUES ('20131008110613');

--- a/spec/acceptance/counter_cacheable_insight_spec.rb
+++ b/spec/acceptance/counter_cacheable_insight_spec.rb
@@ -1,0 +1,25 @@
+require 'acceptance_spec_helper'
+
+feature "counter cacheable insight" do
+  let(:user) { User.make! }
+  let(:app) { App.make!(user: user) }
+  let(:source) { Source.make!(app: app) }
+  let(:request) { Request.make!(source: source) }
+  let!(:counter_cacheable) {
+    CounterCacheableQuerySet.make!(
+      request: request,
+      culprit_association_name: "posts"
+    )
+  }
+
+  background do
+    sign_in_as(user)
+  end
+
+  scenario "Viewing a Source with a recent counter cacheable query set" do
+    visit app_source_path(source.app, source)
+
+    expect_to_see "querying posts"
+    expect_to_see "counter cache column"
+  end
+end

--- a/spec/acceptance/counter_cacheable_insight_spec.rb
+++ b/spec/acceptance/counter_cacheable_insight_spec.rb
@@ -22,4 +22,11 @@ feature "counter cacheable insight" do
     expect_to_see "querying posts"
     expect_to_see "counter cache column"
   end
+
+  scenario "Viewing a Request with a counter cacheable query set" do
+    visit app_request_path(request.app, request)
+
+    expect_to_see "counter cache column"
+    expect_to_see "queries on posts"
+  end
 end

--- a/spec/acceptance/counter_cacheable_insight_spec.rb
+++ b/spec/acceptance/counter_cacheable_insight_spec.rb
@@ -29,4 +29,13 @@ feature "counter cacheable insight" do
     expect_to_see "counter cache column"
     expect_to_see "queries on posts"
   end
+
+  scenario "Viewing the counter cacheable insight" do
+    visit app_counter_cacheable_query_set_path(
+      counter_cacheable.app,
+      counter_cacheable
+    )
+
+    expect_to_see "counter cache column"
+  end
 end

--- a/spec/controllers/counter_cacheable_query_sets_controller_spec.rb
+++ b/spec/controllers/counter_cacheable_query_sets_controller_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+
+describe CounterCacheableQuerySetsController do
+  describe "GET #show" do
+    it_behaves_like "an action requiring authentication as the App's User" do
+      let(:action!) { get :show, app_id: 1, request_id: 2, id: 3 }
+    end
+  end
+end

--- a/spec/decorators/counter_cacheable_query_set_decorator_spec.rb
+++ b/spec/decorators/counter_cacheable_query_set_decorator_spec.rb
@@ -2,17 +2,17 @@ require "draper"
 require_relative "../support/shared/decorates_duration"
 require_relative "../support/shared/has_query_set_statistics"
 require_relative "../../app/decorators/decorates_duration"
-require_relative "../../app/decorators/n_plus_one_query_decorator"
+require_relative "../../app/decorators/counter_cacheable_query_set_decorator"
 
-describe NPlusOneQueryDecorator do
+describe CounterCacheableQuerySetDecorator do
+  subject(:decorated) { CounterCacheableQuerySetDecorator.new(double(:insertable)) }
+
   it_behaves_like "an object with a decorated duration"
 
   it_behaves_like "a query set with timing statistics"
 
   describe "#source_name" do
     it "delegates to the associated source" do
-      decorated = NPlusOneQueryDecorator.new(double(:query))
-
       allow(decorated).to \
         receive(:source).
         and_return(double(:source, name: "sauce name"))
@@ -23,8 +23,6 @@ describe NPlusOneQueryDecorator do
 
   describe "#app_name" do
     it "delegates to the associated app" do
-      decorated = NPlusOneQueryDecorator.new(double(:query))
-
       allow(decorated).to \
         receive(:app).
         and_return(double(:app, name: "mah app"))
@@ -35,8 +33,6 @@ describe NPlusOneQueryDecorator do
 
   describe "#request_name" do
     it "delegates to the associated request" do
-      decorated = NPlusOneQueryDecorator.new(double(:query))
-
       allow(decorated).to \
         receive(:request).
         and_return(double(:request, name: "dat request"))

--- a/spec/gendo/identifies_counter_cacheable_query_sets_spec.rb
+++ b/spec/gendo/identifies_counter_cacheable_query_sets_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../app/gendo/identifies_counter_cacheable_query_sets'
+
+describe IdentifiesCounterCacheableQuerySets do
+  it "groups count queries by association" do
+    count_event = double(
+      "count event",
+      sql: 'SELECT COUNT(*) FROM "comments"  WHERE "comments"."post_id" = $1'
+    )
+
+    insert_event = double(
+      "insert event",
+      sql: "INSERT INTO `bars` (`col`) VALUES (123)"
+    )
+
+    identified = described_class.identify(
+      [count_event, insert_event],
+      minimum_query_occurrences: 1
+    )
+
+    expect(identified).to eq({
+      "comments" => [count_event]
+    })
+  end
+
+  it "requires there to be 5 or more potential queries for a group by default" do
+    queries = []
+    count_events = 5.times.map do
+      event = double(
+        sql: 'SELECT COUNT(*) FROM "foos"  WHERE "foos"."bar_id" = $1'
+      )
+      queries << event
+      event
+    end
+
+    4.times do
+      queries << double(
+        sql: 'SELECT COUNT(*) FROM "bars"  WHERE "bars"."qux_id" = $1'
+      )
+    end
+
+    identified = described_class.identify(queries)
+
+    expect(identified).to eq({"foos" => count_events})
+  end
+end

--- a/spec/gendo/insights/request/add_counter_cache_column_spec.rb
+++ b/spec/gendo/insights/request/add_counter_cache_column_spec.rb
@@ -1,0 +1,27 @@
+require_relative "../../../../app/gendo/insights/request/base"
+require_relative "../../../../app/gendo/insights/request/add_counter_cache_column"
+
+describe Insights::Request::AddCounterCacheColumn do
+  describe "#applicable?" do
+    let(:request) {
+      instance_double("Request", counter_cacheable_query_sets: queries)
+    }
+    subject(:insight) { described_class.new(request) }
+
+    context "with associated counter cacheable query sets" do
+      let(:queries) { [double(:query)] }
+
+      it "is true" do
+        expect(insight.applicable?).to eq(true)
+      end
+    end
+
+    context "without associated counter cacheable query sets" do
+      let(:queries) { [] }
+
+      it "is false" do
+        expect(insight.applicable?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/gendo/insights/source/add_counter_cache_column_spec.rb
+++ b/spec/gendo/insights/source/add_counter_cache_column_spec.rb
@@ -1,0 +1,56 @@
+require "active_support/core_ext/module/delegation"
+require_relative "../../../../app/gendo/insights/source/base"
+require_relative "../../../../app/gendo/insights/source/add_counter_cache_column"
+
+describe Insights::Source::AddCounterCacheColumn do
+  let(:source) { instance_double("Source") }
+  let(:insight) { described_class.new(source) }
+
+  describe "#latest_counter_cacheable" do
+    it "delegates to the source" do
+      latest = double(:latest_counter_cacheable_query_set)
+
+      expect(source).to \
+        receive(:latest_counter_cacheable_query_set).
+        and_return(latest)
+
+      expect(insight.latest_counter_cacheable_query_set).to eq(latest)
+    end
+  end
+
+  describe "#applicable?" do
+    let(:counter_cacheable_query_set) {
+      class_double("CounterCacheableQuerySet").as_stubbed_const
+    }
+    let(:requests) { double(:latest_requests) }
+
+    before do
+      allow(source).to \
+        receive(:latest_requests).
+        with(limit: described_class::REQUESTS_CHECKED_COUNT).
+        and_return(requests)
+    end
+
+    context "when a CounterCacheableQuerySet exists for the latest associated requests" do
+      it "is true" do
+        allow(counter_cacheable_query_set).to \
+          receive(:exists_for_requests?).
+          with(requests).
+          and_return(true)
+
+        expect(insight.applicable?).to eq(true)
+      end
+    end
+
+    context "when no CounterCacheableQuerySet exists for the latest associated requests" do
+      it "is false" do
+        allow(counter_cacheable_query_set).to \
+          receive(:exists_for_requests?).
+          with(requests).
+          and_return(false)
+
+        expect(insight.applicable?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/counter_cacheable_query_set_spec.rb
+++ b/spec/models/counter_cacheable_query_set_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe CounterCacheableQuerySet do
+  describe "#exists_for_requests?" do
+    context "when any of the given requests has an associated CounterCacheableQuerySet" do
+      it "is true" do
+        requests = [Request.make!, CounterCacheableQuerySet.make!.request]
+
+        expect(CounterCacheableQuerySet.exists_for_requests?(requests)).to eq(true)
+      end
+    end
+
+    context "when none of the given requests has an associated CounterCacheableQuerySet" do
+      it "is false" do
+        requests = [Request.make!, Request.make!]
+
+        expect(CounterCacheableQuerySet.exists_for_requests?(requests)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/counter_cacheable_query_set_spec.rb
+++ b/spec/models/counter_cacheable_query_set_spec.rb
@@ -18,4 +18,14 @@ describe CounterCacheableQuerySet do
       end
     end
   end
+
+  describe "#duration" do
+    it "is the sum of associated SQL events" do
+      query = CounterCacheableQuerySet.make!
+      query.sql_events << SqlEvent.make!(duration: 1)
+      query.sql_events << SqlEvent.make!(duration: 2)
+
+      expect(query.duration).to eq(3)
+    end
+  end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -46,6 +46,23 @@ describe Request do
     end
   end
 
+  describe "#create_counter_cacheable_query_set!" do
+    it "creates an associated CounterCacheableQuerySet" do
+      request = Request.make!
+      sql_event = SqlEvent.create!(request: request)
+
+      counter_cacheable= request.create_counter_cacheable_query_set!(
+        "posts",
+        [sql_event]
+      )
+
+      expect(counter_cacheable.request).to eq(request)
+      expect(counter_cacheable.culprit_association_name).to eq("posts")
+      expect(counter_cacheable.sql_events).to eq([sql_event])
+      expect(counter_cacheable.sql_events_count).to eq(1)
+    end
+  end
+
   context "when the given db_runtime is nil" do
     it "sets the db_runtime to 0.0" do
       request = Request.new(db_runtime: nil)

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -68,6 +68,17 @@ describe Source do
     end
   end
 
+  describe "#latest_counter_cacheable_query_set" do
+    it "returns the most recently detected associated CounterCacheableQuerySet" do
+      request = Request.make!
+      CounterCacheableQuerySet.make!(request: request, created_at: 3.days.ago)
+      latest = CounterCacheableQuerySet.make!(request: request, created_at: 1.days.ago)
+      CounterCacheableQuerySet.make!(request: request, created_at: 2.days.ago)
+
+      expect(request.source.latest_counter_cacheable_query_set).to eq(latest)
+    end
+  end
+
   describe "#latest_mailer_event" do
     it "returns the most recently detected associated MailerEvent" do
       request = Request.make!

--- a/spec/support/factories/active_record.rb
+++ b/spec/support/factories/active_record.rb
@@ -21,6 +21,11 @@ BulkInsertable.blueprint do
   column_names { %w(title content) }
 end
 
+CounterCacheableQuerySet.blueprint do
+  request
+  culprit_association_name { "comments" }
+end
+
 MailerEvent.blueprint do
   request
   mailer     { "FooMailer" }

--- a/spec/support/shared/has_query_set_statistics.rb
+++ b/spec/support/shared/has_query_set_statistics.rb
@@ -1,0 +1,47 @@
+shared_examples "a query set with timing statistics" do
+  describe "#percentage_of_db_runtime" do
+    let(:query) { double(duration: 33) }
+    let(:decorated) { described_class.new(query) }
+
+    it "returns the percentage of db_runtime consumed by the query" do
+      allow(decorated).to \
+        receive(:request).
+        and_return(double(:request, db_runtime: "37 ms"))
+
+      expect(decorated.percentage_of_db_runtime).to eq(89.19)
+    end
+
+    context "with a zero db_runtime" do
+      it "is zero" do
+        allow(decorated).to \
+          receive(:request).
+          and_return(double(:request, db_runtime: "0 ms"))
+
+        expect(decorated.percentage_of_db_runtime).to eq(0)
+      end
+    end
+  end
+
+  context "#percentage_of_request_duration" do
+    let(:query) { double(duration: 33) }
+    let(:decorated) { described_class.new(query) }
+
+    it "returns the percentage of db_runtime consumed by the query" do
+      allow(decorated).to \
+        receive(:request).
+        and_return(double(:request, duration: "270 ms"))
+
+      expect(decorated.percentage_of_request_duration).to eq(12.22)
+    end
+
+    context "with a zero db_runtime" do
+      it "is zero" do
+        allow(decorated).to \
+          receive(:request).
+          and_return(double(:request, duration: "0 ms"))
+
+        expect(decorated.percentage_of_request_duration).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/workers/identify_counter_cacheable_query_sets_worker_spec.rb
+++ b/spec/workers/identify_counter_cacheable_query_sets_worker_spec.rb
@@ -1,0 +1,43 @@
+module Sidekiq; module Worker; end; end
+require_relative '../../app/workers/identify_counter_cacheable_query_sets_worker'
+
+describe IdentifyCounterCacheableQuerySetsWorker do
+  describe "#in_request" do
+    it "queues the worker with the given request id" do
+      request = double(:request, id: 123)
+
+      expect(described_class).to \
+        receive(:perform_async).
+        with(request.id)
+
+      described_class.in_request(request)
+    end
+  end
+
+  describe "#perform" do
+    let(:identifier) { 
+      class_double("IdentifiesCounterCacheableQuerySets").as_stubbed_const
+    }
+
+    it "persists counter cacheable query sets identified in the request" do
+      sql_events = double(:sql_events)
+      request = instance_double("Request", id: 123, sql_events: sql_events)
+
+      expect(class_double("Request").as_stubbed_const).to \
+        receive(:find).
+        with(request.id).
+        and_return(request)
+
+      expect(identifier).to \
+        receive(:identify).
+        with(sql_events).
+        and_return({"posts" => sql_events})
+
+      expect(request).to \
+        receive(:create_counter_cacheable_query_set!).
+        with("posts", sql_events)
+
+      described_class.new.perform(request.id)
+    end
+  end
+end

--- a/spec/workers/process_request_payload_worker_spec.rb
+++ b/spec/workers/process_request_payload_worker_spec.rb
@@ -24,6 +24,9 @@ describe ProcessRequestPayloadWorker do
     let(:bulk_insertables_identifier) {
       class_double("IdentifyBulkInsertablesWorker").as_stubbed_const
     }
+    let(:counter_cacheable_query_sets_identifer) {
+      class_double("IdentifyCounterCacheableQuerySetsWorker").as_stubbed_const
+    }
 
     let(:request) { double(:request) }
 
@@ -34,6 +37,7 @@ describe ProcessRequestPayloadWorker do
       allow(creates_request).to receive(:create!).and_return(request)
       allow(n_plus_one_identifier).to receive(:in_request)
       allow(bulk_insertables_identifier).to receive(:in_request)
+      allow(counter_cacheable_query_sets_identifer).to receive(:in_request)
     end
 
     it "creates a Request" do
@@ -55,6 +59,14 @@ describe ProcessRequestPayloadWorker do
 
     it "queues an IdentifyBulkInsertablesWorker" do
       expect(bulk_insertables_identifier).to \
+        receive(:in_request).
+        with(request)
+
+      perform!
+    end
+
+    it "queues an IdentifyCounterCacheableQuerySetsWorker" do
+      expect(counter_cacheable_query_sets_identifer).to \
         receive(:in_request).
         with(request)
 


### PR DESCRIPTION
Suggest that requests that have more than 5 COUNT queries on a table use a counter cache.

Closes #26.
